### PR TITLE
MacOSXの場合にCalcTimeの処理を切り替える

### DIFF
--- a/src/hpc-exercise/utils/mat_util.cpp
+++ b/src/hpc-exercise/utils/mat_util.cpp
@@ -756,7 +756,43 @@ void CalcTime::end()
 }
 
 #else
-#ifdef __GNUC__
+#ifdef __APPLE__
+
+#include <mach/mach_time.h>
+#define ORWL_NANO (+1.0E-9)
+#define ORWL_GIGA UINT64_C(1000000000)
+
+static double orwl_timebase = 0.0;
+static uint64_t orwl_timestart = 0;
+
+struct timespec orwl_gettime(void) {
+  if (!orwl_timestart) {
+    mach_timebase_info_data_t tb = { 0 };
+    mach_timebase_info(&tb);
+    orwl_timebase = tb.numer;
+    orwl_timebase /= tb.denom;
+    orwl_timestart = mach_absolute_time();
+  }
+  struct timespec t;
+  double diff = (mach_absolute_time() - orwl_timestart) * orwl_timebase;
+  t.tv_sec = diff * ORWL_NANO;
+  t.tv_nsec = diff - (t.tv_sec * ORWL_GIGA);
+  return t;
+}
+
+void CalcTime::start()
+{
+    s = orwl_gettime();
+    return;
+}
+
+void CalcTime::end()
+{
+    e = orwl_gettime();
+    que.push_back((double)(e.tv_sec - s.tv_sec) * 1e3 + (double)(e.tv_nsec - s.tv_nsec) * 1e-6); //ms
+    return;
+}
+#elif __GNUC__
 void CalcTime::start()
 {
 	clock_gettime(CLOCK_REALTIME, &s);


### PR DESCRIPTION
# 概要
- 時間計測に用いる`CalcTime`構造体の内部で使用している`clock_gettime`が
MacOSXの場合にマイクロ秒までしか計測できないので
ナノ秒まで計測できるように変更を加える

# 実装
- `CalcTime`の`start()`, `end()`のマクロ分岐に`__APPLE__`を追加しOSがMacOSXの場合に分岐させる
- `mach/mach_time.h`の`mach_absolute_time()`を使用する